### PR TITLE
0827-dr

### DIFF
--- a/app/controllers/battles_controller.rb
+++ b/app/controllers/battles_controller.rb
@@ -12,15 +12,22 @@ class BattlesController < ApplicationController
 
   def create
     @battle = Battle.new(battle_params)
+
+    # hiddenフィールドから受け取ったカード情報を設定
     @battle.user_card = params[:battle][:user_card].to_i
+    @battle.opponent_card = params[:battle][:opponent_card].to_i
 
-    # ユーザーカードと異なる相手カードを確実に選択
-    available_cards = (1..13).to_a - [@battle.user_card]
-    @battle.opponent_card = available_cards.sample
+    # 引き分けの場合はユーザーカードを変更（見えないので問題なし）
+    if @battle.user_card == @battle.opponent_card
+      available_user_cards = (1..13).to_a - [@battle.opponent_card]
+      @battle.user_card = available_user_cards.sample
+    end
 
+    # 勝敗判定（引き分けは発生しない）
     winner_user = @battle.determine_winner
     message = "戦闘が完了しました！#{winner_user.name}の勝利です！"
 
+    # 勝敗を設定
     @battle.winner_id = winner_user.id
     @battle.loser_id = winner_user == @battle.user ? @battle.opponent.id : @battle.user.id
 


### PR DESCRIPTION

引き分けの設定がバグっていたので、
自動再戦ならないように設定。

最初のドローで引き分けの場合、
結果発表時にユーザーのカードが変わるように設定。
（UX的に問題ないはず）