### PR TITLE
add:💡dbのバックアップをダンプ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@
 !/app/assets/builds/.keep
 
 /node_modules
+render_backup.sql


### PR DESCRIPTION

 dbをRenderからNeonへ移行。
その際のバックアップをsqlでダンプ。
.gitignoreに保存。